### PR TITLE
Clusterwide EditTopology request

### DIFF
--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -289,7 +289,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 		reqLogger.Info("All replicas in replicaset explored, fetching replicaset topology values")
 		if currentReplicaset, err := topologyClient.GetReplicasetValues(replicas, sts.GetName()); err != nil {
-			reqLogger.Info("Failed to fetch topology values from replicaset")
+			reqLogger.Error(err, "Failed to fetch topology values from replicaset")
 			return ctrl.Result{RequeueAfter: time.Duration(errorTimeout * time.Second)}, err
 		} else {
 			replicasets = append(replicasets, *currentReplicaset)
@@ -302,7 +302,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		reqLogger.Info("Sending clusterwide EditTopology request")
 
 		if _, err := topologyClient.EditTopology(replicasets); err != nil {
-			reqLogger.Info("Failed to execute EditTopology request")
+			reqLogger.Error(err, "Failed to execute EditTopology request")
 			return ctrl.Result{RequeueAfter: time.Duration(errorTimeout * time.Second)}, err
 		}
 		reqLogger.Info("Successfull EditTopology request, marking pods as joined")

--- a/controllers/role_controller.go
+++ b/controllers/role_controller.go
@@ -31,6 +31,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -38,8 +39,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -246,6 +249,10 @@ func (r *RoleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			}
 			return res
 		})).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: 1,
+			RateLimiter:             workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, 10*time.Second),
+		}).
 		Complete(r)
 }
 


### PR DESCRIPTION
In order to fix bug, when replicasets appeared in different clusters, EditToplogy is sent to all replicasets at once, instead of sending consequent requests for each replicaset.